### PR TITLE
fix: forbid empty params for some filters

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -78,6 +78,11 @@ var resourceBuilderTests = []resourceBuilderTest{
 		expectedErr: true,
 	},
 	{
+		title:       "Filter is present but value not specified",
+		query:       fmt.Sprintf("filter[%s]=%s:", resourceFieldTitle, filterEq),
+		expectedErr: true,
+	},
+	{
 		title:       "Not allowed sorting",
 		query:       "sort=id",
 		expectedErr: true,

--- a/filter.go
+++ b/filter.go
@@ -1,6 +1,9 @@
 package q2sql
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	mainDelim = ':'
@@ -48,6 +51,9 @@ func (d *DelimitedArgsParser) ParseFilterExpression(expr string) (name string, a
 	}
 	name, expr = expr[:i], expr[i+1:]
 	if expr == "" {
+		if name != "notnull" && name != "null" {
+			return "", nil, fmt.Errorf("for filter %s value must be specified", name)
+		}
 		return name, nil, nil
 	}
 	return name, strings.Split(expr, d.argsDelim), nil


### PR DESCRIPTION
at the moment it is allowed to provide filters like that:
`filter[title]=eq:`
so, there is no value specfified for equiality and it might cause a lot of problems on SQL generation, since it can produce SQL similar to:
`SELECT ... FROM ... WHERE `
or somewhere in the middle:
`SELECT ... FROM ... WHERE AND description CONTAINS ...`
which is incorrect SQL and must be prevented